### PR TITLE
Enhance perfomance by reducing icon updates

### DIFF
--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -31,6 +31,7 @@ var NodeModel = widgets.WidgetModel.extend({
 
     initialize: function() {
         NodeModel.__super__.initialize.apply(this, arguments);
+
         nodesRegistry[this.get('_id')] = this;
     }
 }, {
@@ -42,6 +43,7 @@ var NodeModel = widgets.WidgetModel.extend({
 var NodeView = widgets.WidgetView.extend({
     initialize: function (parameters) {
         NodeView.__super__.initialize.apply(this, arguments);
+
         this.parentModel = this.options.parentModel;
         this.treeView = this.options.treeView;
 
@@ -103,6 +105,7 @@ var NodeView = widgets.WidgetView.extend({
         var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
+
         if(this.model.get('nodes').length == 0) {
             icon_element.removeClass(open_icon).removeClass(close_icon);
             return;
@@ -203,7 +206,7 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleNodesChange: function() {
-      this.nodeViews.update(this.model.get('nodes')); 
+        this.nodeViews.update(this.model.get('nodes')); 
     },
 
     remove: function() {
@@ -342,7 +345,6 @@ var TreeView = widgets.DOMWidgetView.extend({
         this.stopListening(this.model);
     },
 });
-
 
 module.exports = {
     NodeModel: NodeModel,

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -106,7 +106,8 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     setOpenCloseIcon: function() {
-        var open_icon = this.getOpenIcon();
+        console.log("Updating icons for real");
+				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
 
@@ -125,10 +126,13 @@ var NodeView = widgets.WidgetView.extend({
         }
 
         if(this.model.get('opened')) {
+						console.log("opened");
             icon_element.removeClass(open_icon).addClass(close_icon);
         } else {
+						console.log("closed");
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
+				console.log(icon_element);
     },
 
     onRendered: function() {
@@ -149,8 +153,13 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:close_icon_style', this.setOpenCloseIcon);
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
-
+				console.log("Parent icons about to be updated");	
+				//this.setOpenCloseIcon();
+				//console.log(this.parentModel);
+				this.parentModel.trigger('icons_update');
+				this.parentModel.trigger('change:icon');
         //triggerIconsUpdate();
+				console.log("Parent icons updated");
     },
 
     addNodeModel: function(nodeModel) {
@@ -172,7 +181,8 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleOpenedChange: function() {
-        triggerIconsUpdate();
+       // triggerIconsUpdate();
+				this.setOpenCloseIcon();
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
         } else {
@@ -201,9 +211,9 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleNodesChange: function() {
-        this.nodeViews.update(this.model.get('nodes'));
-        triggerIconsUpdate();
-    },
+    	this.nodeViews.update(this.model.get('nodes'));	
+			this.setOpenCloseIcon();
+		},
 
     remove: function() {
         NodeView.__super__.remove.apply(this, arguments);
@@ -264,6 +274,8 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
+			console.log("RENDERED");
+			triggerIconsUpdate();
     },
 
     initTreeEventListeners: function() {
@@ -313,7 +325,6 @@ var TreeView = widgets.DOMWidgetView.extend({
                 });
                 this.model.set('selected_nodes', selected_nodes);
                 this.model.save_changes();
-								triggerIconsUpdate();
             }
         );
     },

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -8,6 +8,7 @@ require('jstree');
 
 var nodesRegistry = {};
 var triggerIconsUpdate = function() {
+		console.log("Icons updated");
     for(var id in nodesRegistry) {
         nodesRegistry[id].trigger('icons_update');
     }
@@ -36,7 +37,6 @@ var NodeModel = widgets.WidgetModel.extend({
 
     initialize: function() {
         NodeModel.__super__.initialize.apply(this, arguments);
-
         nodesRegistry[this.get('_id')] = this;
     }
 }, {
@@ -48,7 +48,6 @@ var NodeModel = widgets.WidgetModel.extend({
 var NodeView = widgets.WidgetView.extend({
     initialize: function (parameters) {
         NodeView.__super__.initialize.apply(this, arguments);
-
         this.parentModel = this.options.parentModel;
         this.treeView = this.options.treeView;
 
@@ -151,7 +150,7 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
 
-        triggerIconsUpdate();
+        //triggerIconsUpdate();
     },
 
     addNodeModel: function(nodeModel) {
@@ -255,8 +254,9 @@ var TreeView = widgets.DOMWidgetView.extend({
                 this.tree = $(this.el).jstree(true);
 
                 this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
-                this.nodeViews.update(this.model.get('nodes'));
-
+								console.log("Before updating");
+								this.nodeViews.update(this.model.get('nodes'));
+								console.log("After updating");
                 this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
 
                 this.initTreeEventListeners();
@@ -313,6 +313,7 @@ var TreeView = widgets.DOMWidgetView.extend({
                 });
                 this.model.set('selected_nodes', selected_nodes);
                 this.model.save_changes();
+								triggerIconsUpdate();
             }
         );
     },

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -8,7 +8,6 @@ require('jstree');
 
 var nodesRegistry = {};
 var triggerIconsUpdate = function() {
-		//console.log("Icons updated");
     for(var id in nodesRegistry) {
         nodesRegistry[id].trigger('icons_update');
     }
@@ -38,9 +37,6 @@ var NodeModel = widgets.WidgetModel.extend({
     initialize: function() {
         NodeModel.__super__.initialize.apply(this, arguments);
         nodesRegistry[this.get('_id')] = this;
-				//this.trigger('icons_update');
-				//this.trigger('change:icon');
-				//console.log(this);
     }
 }, {
     serializers: _.extend({
@@ -52,8 +48,6 @@ var NodeView = widgets.WidgetView.extend({
     initialize: function (parameters) {
         NodeView.__super__.initialize.apply(this, arguments);
         this.parentModel = this.options.parentModel;
-				//console.log("Options:");
-				//console.log(this.options);
         this.treeView = this.options.treeView;
 
         this.treeView.waitTree.then(() => {
@@ -111,7 +105,6 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     setOpenCloseIcon: function() {
-        //console.log("Updating icons for real");
 				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
@@ -131,13 +124,10 @@ var NodeView = widgets.WidgetView.extend({
         }
 
         if(this.model.get('opened')) {
-						//console.log("opened");
             icon_element.removeClass(open_icon).addClass(close_icon);
         } else {
-						//console.log("closed");
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
-				//console.log(icon_element);
     },
 		// Called once at the beginning, when the node is first created
     onRendered: function() {
@@ -158,23 +148,14 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:close_icon_style', this.setOpenCloseIcon);
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
-				//console.log("Parent icons about to be updated");	
-				//this.setOpenCloseIcon();
-				//console.log(this.parentModel);
 				// Update parent, so icon of parent is correct
-				// TODO: Reduce how often this is called; 
-				// Maybe add own function for this that returns immediately if children were already present
 				// Relevant only, if parent had not had any children yet
-				//if(this.parentModel.get('nodes').length == 1){
+				if(this.parentModel.get('nodes').length == 1){
 					this.parentModel.trigger('icons_update');
-				//}
-				//this.parentModel.trigger('change:icon');
-        //triggerIconsUpdate();
-				//console.log("Parent icons updated");
+				}
     },
 
     addNodeModel: function(nodeModel) {
-				//this.iconChanged = true;
         return this.create_child_view(nodeModel, {
             treeView: this.treeView,
             parentModel: this.model
@@ -193,10 +174,7 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleOpenedChange: function() {
-  			//console.log(this);
-				//triggerIconsUpdate();
 				this.setOpenCloseIcon();
-				//this.iconChanged = false;
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
 						for(var node in this.nodeViewList) {
@@ -204,20 +182,11 @@ var NodeView = widgets.WidgetView.extend({
 							// Optimal way to do it already, needs to be called on every open
 							// for every child, else it will not have an icon
 							this.nodeViewList[node].handleOpenedChange();
-							//this.handleChildrenOpenClose();
 						}
         } else {
             this.tree.close_node(this.model.get('_id'));
         }
     },
-
-		//handleChildrenOpenClose: function(){
-		//	if(this.model.get('opened')){
-		//		for(var child in this.nodeViewList){
-		//			this.nodeViewList[child].handleChildrenOpenClose();
-		//		}
-		//	}
-		//}
 
     handleDisabledChange: function() {
         if(this.model.get('disabled')) {
@@ -293,9 +262,7 @@ var TreeView = widgets.DOMWidgetView.extend({
                 this.tree = $(this.el).jstree(true);
 
                 this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
-								//console.log("Before updating");
 								this.nodeViews.update(this.model.get('nodes'));
-								//console.log("After updating");
                 this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
 
                 this.initTreeEventListeners();
@@ -303,7 +270,6 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
-			//console.log("RENDERED");
 			triggerIconsUpdate();
     },
 
@@ -340,8 +306,6 @@ var TreeView = widgets.DOMWidgetView.extend({
             "after_open.jstree", (evt, data) => {
                 nodesRegistry[data.node.id].set('opened', true);
                 nodesRegistry[data.node.id].save_changes();
-								//triggerIconsUpdate();
-								//console.log("After open");
             }
         ).bind(
             "close_node.jstree", (evt, data) => {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -123,12 +123,12 @@ var NodeView = widgets.WidgetView.extend({
         if(this.model.get('opened')) {
             icon_element.removeClass(open_icon).addClass(close_icon);
             if(recursive){
-            for(var node in this.nodeViewList) {
-                // Recursion in order to make icons on all opened levels correct
-                // Optimal way to do it already, needs to be called on every open
-                // for every child, else it will not have an icon
-                this.nodeViewList[node].setOpenCloseIcon(recursive);
-              }
+                for(var node in this.nodeViewList) {
+                    // Recursion in order to make icons on all opened levels correct
+                    // Optimal way to do it already, needs to be called on every open
+                    // for every child, else it will not have an icon
+                    this.nodeViewList[node].setOpenCloseIcon(recursive);
+                }
             }
         } else {
             icon_element.removeClass(close_icon).addClass(open_icon);

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -207,7 +207,6 @@ var NodeView = widgets.WidgetView.extend({
 
     handleNodesChange: function() {
     	this.nodeViews.update(this.model.get('nodes'));	
-			this.setOpenCloseIcon();
 		},
 
     remove: function() {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -147,10 +147,9 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
 				// Update parent, so icon of parent is correct
-				// Relevant only, if parent had not had any children yet
-				if(this.parentModel.get('nodes').length == 1){
-					this.parentModel.trigger('icons_update');
-				}
+				// Needs to be called every time a new child is added
+				// Else parent icon will not be shown after adding child
+				this.parentModel.trigger('icons_update');
     },
 
     addNodeModel: function(nodeModel) {
@@ -268,7 +267,6 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
-			triggerIconsUpdate();
     },
 
     initTreeEventListeners: function() {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -115,8 +115,8 @@ var NodeView = widgets.WidgetView.extend({
 				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
-
-        if(this.model.get('nodes').length == 0) {
+				// This is okay, because JS passes arrays by reference
+				if(this.model.get('nodes').length == 0) {
             icon_element.removeClass(open_icon).removeClass(close_icon);
             return;
         }
@@ -161,13 +161,20 @@ var NodeView = widgets.WidgetView.extend({
 				//console.log("Parent icons about to be updated");	
 				//this.setOpenCloseIcon();
 				//console.log(this.parentModel);
-				this.parentModel.trigger('icons_update');
-				this.parentModel.trigger('change:icon');
+				// Update parent, so icon of parent is correct
+				// TODO: Reduce how often this is called; 
+				// Maybe add own function for this that returns immediately if children were already present
+				// Relevant only, if parent had not had any children yet
+				//if(this.parentModel.get('nodes').length == 1){
+					this.parentModel.trigger('icons_update');
+				//}
+				//this.parentModel.trigger('change:icon');
         //triggerIconsUpdate();
 				//console.log("Parent icons updated");
     },
 
     addNodeModel: function(nodeModel) {
+				//this.iconChanged = true;
         return this.create_child_view(nodeModel, {
             treeView: this.treeView,
             parentModel: this.model
@@ -189,15 +196,16 @@ var NodeView = widgets.WidgetView.extend({
   			//console.log(this);
 				//triggerIconsUpdate();
 				this.setOpenCloseIcon();
+				//this.iconChanged = false;
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
-    				for(var node in this.nodeViewList) {
-        			// Recursion in order to make icons on all opened levels correct
-							//this.nodeViewList[node].model.trigger('icons_update');
-        			this.nodeViewList[node].handleOpenedChange();
-							//console.log("Open changed on", this.nodeViewList[node]);
+						for(var node in this.nodeViewList) {
+							// Recursion in order to make icons on all opened levels correct
+							// Optimal way to do it already, needs to be called on every open
+							// for every child, else it will not have an icon
+							this.nodeViewList[node].handleOpenedChange();
 							//this.handleChildrenOpenClose();
-    				}
+						}
         } else {
             this.tree.close_node(this.model.get('_id'));
         }

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -108,7 +108,6 @@ var NodeView = widgets.WidgetView.extend({
 				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
-				// This is okay, because JS passes arrays by reference
 				if(this.model.get('nodes').length == 0) {
             icon_element.removeClass(open_icon).removeClass(close_icon);
             return;
@@ -129,7 +128,6 @@ var NodeView = widgets.WidgetView.extend({
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
     },
-		// Called once at the beginning, when the node is first created
     onRendered: function() {
         this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
         this.nodeViews.update(this.model.get('nodes'));

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -124,6 +124,12 @@ var NodeView = widgets.WidgetView.extend({
 
         if(this.model.get('opened')) {
             icon_element.removeClass(open_icon).addClass(close_icon);
+						for(var node in this.nodeViewList) {
+							// Recursion in order to make icons on all opened levels correct
+							// Optimal way to do it already, needs to be called on every open
+							// for every child, else it will not have an icon
+							this.nodeViewList[node].setOpenCloseIcon();
+						}
         } else {
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
@@ -174,12 +180,6 @@ var NodeView = widgets.WidgetView.extend({
 				this.setOpenCloseIcon();
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
-						for(var node in this.nodeViewList) {
-							// Recursion in order to make icons on all opened levels correct
-							// Optimal way to do it already, needs to be called on every open
-							// for every child, else it will not have an icon
-							this.nodeViewList[node].handleOpenedChange();
-						}
         } else {
             this.tree.close_node(this.model.get('_id'));
         }
@@ -267,8 +267,6 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
-			// TODO: Remove? Adding a peer causes loss of icons
-			triggerIconsUpdate();
     },
 
     initTreeEventListeners: function() {
@@ -335,6 +333,13 @@ var TreeView = widgets.DOMWidgetView.extend({
 
     handleNodesChange: function() {
         this.nodeViews.update(this.model.get('nodes'));
+				// If top level nodes are changed, icons disappear
+				// So reload them for all visible nodes
+				Promise.all(this.nodeViews.views).then(function(views) {
+					for(var view in views){
+						views[view].setOpenCloseIcon();
+					}
+				});
     },
 
     remove: function() {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -7,11 +7,6 @@ require('./theme/style.css');
 require('jstree');
 
 var nodesRegistry = {};
-var triggerIconsUpdate = function() {
-    for(var id in nodesRegistry) {
-        nodesRegistry[id].trigger('icons_update');
-    }
-}
 
 var NodeModel = widgets.WidgetModel.extend({
     defaults: _.extend(widgets.WidgetModel.prototype.defaults(), {
@@ -104,7 +99,7 @@ var NodeView = widgets.WidgetView.extend({
             .find('i.jstree-icon.jstree-ocl').first();
     },
 
-    setOpenCloseIcon: function() {
+    setOpenCloseIcon: function(recursive=false) {
 				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
@@ -128,7 +123,7 @@ var NodeView = widgets.WidgetView.extend({
 							// Recursion in order to make icons on all opened levels correct
 							// Optimal way to do it already, needs to be called on every open
 							// for every child, else it will not have an icon
-							this.nodeViewList[node].setOpenCloseIcon();
+							this.nodeViewList[node].setOpenCloseIcon(recursive);
 						}
         } else {
             icon_element.removeClass(close_icon).addClass(open_icon);
@@ -177,7 +172,7 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleOpenedChange: function() {
-				this.setOpenCloseIcon();
+				this.setOpenCloseIcon(true);
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
         } else {
@@ -336,7 +331,7 @@ var TreeView = widgets.DOMWidgetView.extend({
 				// So reload them for all visible nodes
 				Promise.all(this.nodeViews.views).then(function(views) {
 					for(var view in views){
-						views[view].setOpenCloseIcon();
+						views[view].setOpenCloseIcon(true);
 					}
 				});
     },

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -8,7 +8,7 @@ require('jstree');
 
 var nodesRegistry = {};
 var triggerIconsUpdate = function() {
-		console.log("Icons updated");
+		//console.log("Icons updated");
     for(var id in nodesRegistry) {
         nodesRegistry[id].trigger('icons_update');
     }
@@ -38,6 +38,9 @@ var NodeModel = widgets.WidgetModel.extend({
     initialize: function() {
         NodeModel.__super__.initialize.apply(this, arguments);
         nodesRegistry[this.get('_id')] = this;
+				//this.trigger('icons_update');
+				//this.trigger('change:icon');
+				//console.log(this);
     }
 }, {
     serializers: _.extend({
@@ -49,6 +52,8 @@ var NodeView = widgets.WidgetView.extend({
     initialize: function (parameters) {
         NodeView.__super__.initialize.apply(this, arguments);
         this.parentModel = this.options.parentModel;
+				//console.log("Options:");
+				//console.log(this.options);
         this.treeView = this.options.treeView;
 
         this.treeView.waitTree.then(() => {
@@ -106,7 +111,7 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     setOpenCloseIcon: function() {
-        console.log("Updating icons for real");
+        //console.log("Updating icons for real");
 				var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
@@ -126,15 +131,15 @@ var NodeView = widgets.WidgetView.extend({
         }
 
         if(this.model.get('opened')) {
-						console.log("opened");
+						//console.log("opened");
             icon_element.removeClass(open_icon).addClass(close_icon);
         } else {
-						console.log("closed");
+						//console.log("closed");
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
-				console.log(icon_element);
+				//console.log(icon_element);
     },
-
+		// Called once at the beginning, when the node is first created
     onRendered: function() {
         this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
         this.nodeViews.update(this.model.get('nodes'));
@@ -153,13 +158,13 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:close_icon_style', this.setOpenCloseIcon);
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
-				console.log("Parent icons about to be updated");	
+				//console.log("Parent icons about to be updated");	
 				//this.setOpenCloseIcon();
 				//console.log(this.parentModel);
 				this.parentModel.trigger('icons_update');
 				this.parentModel.trigger('change:icon');
         //triggerIconsUpdate();
-				console.log("Parent icons updated");
+				//console.log("Parent icons updated");
     },
 
     addNodeModel: function(nodeModel) {
@@ -181,14 +186,30 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleOpenedChange: function() {
-       // triggerIconsUpdate();
+  			//console.log(this);
+				//triggerIconsUpdate();
 				this.setOpenCloseIcon();
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
+    				for(var node in this.nodeViewList) {
+        			// Recursion in order to make icons on all opened levels correct
+							//this.nodeViewList[node].model.trigger('icons_update');
+        			this.nodeViewList[node].handleOpenedChange();
+							//console.log("Open changed on", this.nodeViewList[node]);
+							//this.handleChildrenOpenClose();
+    				}
         } else {
             this.tree.close_node(this.model.get('_id'));
         }
     },
+
+		//handleChildrenOpenClose: function(){
+		//	if(this.model.get('opened')){
+		//		for(var child in this.nodeViewList){
+		//			this.nodeViewList[child].handleChildrenOpenClose();
+		//		}
+		//	}
+		//}
 
     handleDisabledChange: function() {
         if(this.model.get('disabled')) {
@@ -264,9 +285,9 @@ var TreeView = widgets.DOMWidgetView.extend({
                 this.tree = $(this.el).jstree(true);
 
                 this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
-								console.log("Before updating");
+								//console.log("Before updating");
 								this.nodeViews.update(this.model.get('nodes'));
-								console.log("After updating");
+								//console.log("After updating");
                 this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
 
                 this.initTreeEventListeners();
@@ -274,7 +295,7 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
-			console.log("RENDERED");
+			//console.log("RENDERED");
 			triggerIconsUpdate();
     },
 
@@ -311,6 +332,8 @@ var TreeView = widgets.DOMWidgetView.extend({
             "after_open.jstree", (evt, data) => {
                 nodesRegistry[data.node.id].set('opened', true);
                 nodesRegistry[data.node.id].save_changes();
+								//triggerIconsUpdate();
+								//console.log("After open");
             }
         ).bind(
             "close_node.jstree", (evt, data) => {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -100,10 +100,10 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     setOpenCloseIcon: function(recursive=false) {
-				var open_icon = this.getOpenIcon();
+        var open_icon = this.getOpenIcon();
         var close_icon = this.getCloseIcon();
         var icon_element = this.getOpenCloseIconElement();
-				if(this.model.get('nodes').length == 0) {
+        if(this.model.get('nodes').length == 0) {
             icon_element.removeClass(open_icon).removeClass(close_icon);
             return;
         }
@@ -119,12 +119,14 @@ var NodeView = widgets.WidgetView.extend({
 
         if(this.model.get('opened')) {
             icon_element.removeClass(open_icon).addClass(close_icon);
-						for(var node in this.nodeViewList) {
-							// Recursion in order to make icons on all opened levels correct
-							// Optimal way to do it already, needs to be called on every open
-							// for every child, else it will not have an icon
-							this.nodeViewList[node].setOpenCloseIcon(recursive);
-						}
+            if(recursive){
+            for(var node in this.nodeViewList) {
+                // Recursion in order to make icons on all opened levels correct
+                // Optimal way to do it already, needs to be called on every open
+                // for every child, else it will not have an icon
+                this.nodeViewList[node].setOpenCloseIcon(recursive);
+              }
+            }
         } else {
             icon_element.removeClass(close_icon).addClass(open_icon);
         }
@@ -147,10 +149,10 @@ var NodeView = widgets.WidgetView.extend({
         this.listenTo(this.model, 'change:close_icon_style', this.setOpenCloseIcon);
         this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
         this.listenTo(this.model, 'icons_update', this.setOpenCloseIcon);
-				// Update parent, so icon of parent is correct
-				// Needs to be called every time a new child is added
-				// Else parent icon will not be shown after adding child
-				this.parentModel.trigger('icons_update');
+        // Update parent, so icon of parent is correct
+        // Needs to be called every time a new child is added
+        // Else parent icon will not be shown after adding child
+        this.parentModel.trigger('icons_update');
     },
 
     addNodeModel: function(nodeModel) {
@@ -172,7 +174,7 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleOpenedChange: function() {
-				this.setOpenCloseIcon(true);
+        this.setOpenCloseIcon(true);
         if(this.model.get('opened')) {
             this.tree.open_node(this.model.get('_id'));
         } else {
@@ -201,8 +203,8 @@ var NodeView = widgets.WidgetView.extend({
     },
 
     handleNodesChange: function() {
-    	this.nodeViews.update(this.model.get('nodes'));	
-		},
+      this.nodeViews.update(this.model.get('nodes')); 
+    },
 
     remove: function() {
         NodeView.__super__.remove.apply(this, arguments);
@@ -253,7 +255,7 @@ var TreeView = widgets.DOMWidgetView.extend({
                 this.tree = $(this.el).jstree(true);
 
                 this.nodeViews = new widgets.ViewList(this.addNodeModel, this.removeNodeView, this);
-								this.nodeViews.update(this.model.get('nodes'));
+                this.nodeViews.update(this.model.get('nodes'));
                 this.listenTo(this.model, 'change:nodes', this.handleNodesChange);
 
                 this.initTreeEventListeners();
@@ -327,13 +329,13 @@ var TreeView = widgets.DOMWidgetView.extend({
 
     handleNodesChange: function() {
         this.nodeViews.update(this.model.get('nodes'));
-				// If top level nodes are changed, icons disappear
-				// So reload them for all visible nodes
-				Promise.all(this.nodeViews.views).then(function(views) {
-					for(var view in views){
-						views[view].setOpenCloseIcon(true);
-					}
-				});
+        // If top level nodes are changed, icons disappear
+        // So reload them for all visible nodes
+        Promise.all(this.nodeViews.views).then(function(views) {
+          for(var view in views){
+            views[view].setOpenCloseIcon(true);
+          }
+        });
     },
 
     remove: function() {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -267,6 +267,8 @@ var TreeView = widgets.DOMWidgetView.extend({
                 resolve();
             });
         });
+			// TODO: Remove? Adding a peer causes loss of icons
+			triggerIconsUpdate();
     },
 
     initTreeEventListeners: function() {


### PR DESCRIPTION
I'm using ipytree in a project for displaying a hierarchy of multiple hundreds of objects. I found it very useful in this context, but noticed a considerable delay (> 30 sec) and high CPU and RAM (> 1 GB) usage when first constructing such large trees. So I looked into the code and found that triggerIconsUpdate() is called very often causing some overhead.

This pull request implements changes that greatly reduce the number of times icons are updated, thus also reducing time (down to ~5 sec for my use case) and CPU/RAM usage for building a large tree. If I did not miss anything, the layout of the tree remains consistent, so the icons are always shown as expected.

This is done by updating (open/close) icons only at the following times:
- When a child is added, the parent will update its icon.
- When a parent is opened, the icons of all children are updated recursively. This means if a node is opened, all its immediate children will update their icons and check if they are open. If so, their children will also update their icons and check if they are open, and so on. This makes sure all visible nodes have correct icons.
- Whenever the top level nodes are changed, icons are updated on all top level nodes and recursively on their visible children. This was introduced because adding a new top level node caused all icons to disappear.

The following is a relatively minimal example to showcase what I mean:

```
from ipytree import Tree, Node
tree = Tree(stripes=True)
tree
```

```
for i in range(5):
    tree.add_node(Node(str(i)))
    tree.nodes[i].opened = False
    for j in range(200):
        tree.nodes[i].add_node(Node(str(j)))
```

The time for running this code was reduced from about 30 seconds to below 5 seconds on my machine.