### PR TITLE
Change jstree dependency to "~3.3.9"

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2.0",
-    "jstree": "3.3.5",
+    "jstree": "~3.3.9",
     "lodash": "^4.17.4"
   },
   "jupyterlab": {


### PR DESCRIPTION
fixes #21

@martinRenou `ipytree/js/package-lock.json` will also need to be updated to reflect the change in the dependency. Should I do that as part of this PR, or will that be taken care of as part of your release process?