### PR TITLE
add license to js package

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.6",
   "description": "A Tree Widget using jsTree",
   "author": "Martin Renou",
+  "license": "MIT",
   "main": "lib/index.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Thanks for helping me fix the security issue. Turns out I still can't use ipytree since there's no license specified in the js package (our auto-procurement system isn't smart enough to also check the repo). This PR adds the license to package.json.

@martinRenou Could you please do another release after this gets pulled in?