### PR TITLE
Fix Deprecated way of constructing traitlets. 

### DIFF
--- a/ipytree/tree.py
+++ b/ipytree/tree.py
@@ -41,7 +41,7 @@ class Node(Widget):
     close_icon = Unicode("minus").tag(sync=True)
     close_icon_style = Enum(values=_style_values, default_value="default").tag(sync=True)
 
-    nodes = Tuple(trait=Instance(Widget)).tag(
+    nodes = Tuple().tag(trait=Instance(Widget),
         sync=True, **widget_serialization)
 
     _id = Unicode(read_only=True).tag(sync=True)
@@ -84,10 +84,10 @@ class Tree(DOMWidget):
     _view_module_version = Unicode(__version__).tag(sync=True)
     _model_module_version = Unicode(__version__).tag(sync=True)
 
-    nodes = Tuple(trait=Instance(Node)).tag(sync=True, **widget_serialization)
+    nodes = Tuple().tag(trait=Instance(Node), sync=True, **widget_serialization)
     multiple_selection = Bool(True, read_only=True).tag(sync=True)
     animation = Int(200, read_only=True).tag(sync=True)
-    selected_nodes = Tuple(trait=Instance(Node), read_only=True).tag(sync=True, **widget_serialization)
+    selected_nodes = Tuple(read_only=True).tag(trait=Instance(Node),sync=True, **widget_serialization)
 
     _id = Unicode('#', read_only=True).tag(sync=True)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+doctest_optionflags = NORMALIZE_WHITESPACE ELLIPSIS IGNORE_EXCEPTION_DETAIL
+filterwarnings =
+    error::DeprecationWarning
+

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,9 @@
+from ipytree import Tree, Node
+
+
+def test_tree():
+    Tree()
+
+
+def test_node():
+    Node()


### PR DESCRIPTION
while testing Zarr with Deprecation warnings as error, I came across this. 