### PR TITLE
Update the link to the repo in package.json

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,7 +7,7 @@
   "main": "lib/index.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/martinRenou/ipytree.git"
+    "url": "https://github.com/QuantStack/ipytree.git"
   },
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Minor fix to the link to the repo in package.json.

GitHub still handles the redirect for now because there doesn't seem to be a fork under https://github.com/martinRenou/ipytree.