### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,38 @@
+name: Build
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+       node-version: '10.x'
+    - name: Install Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install jupyterlab
+    - name: Install the ipytree Python package
+      run: |
+        python -m pip install .
+        jupyter nbextension list 2>&1 | grep -ie "ipytree/extension.*enabled" -
+    - name: Install the ipytree JupyterLab extension
+      run: |
+        jupyter labextension install js
+        jupyter labextension list 2>&1 | grep -ie "ipytree.*enabled.*ok" -
+    - name: Browser check
+      run: |
+        python -m jupyterlab.browser_check


### PR DESCRIPTION
Add a GitHub Actions workflow to install `ipytree` and check the classic notebook and JupyterLab extensions are correctly installed. 

This should be useful when we move the new lab extension system in a follow-up PR, so we can make sure extensions are installed correctly on `pip install`.