### PR TITLE
[WIP] Drag and drop support

### DIFF
--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -324,7 +324,6 @@ var TreeView = widgets.DOMWidgetView.extend({
             }
         ).bind(
             "move_node.jstree", (evt, data) => {
-
                 var nodes1 = [];  // new value for old_parent.children
                 data.instance._model.data[data.old_parent].children.slice().forEach((id) => {
                     nodes1.push(nodesRegistry[id]);
@@ -336,6 +335,8 @@ var TreeView = widgets.DOMWidgetView.extend({
                 });
 
                 if (data.old_parent == "#") {
+                    // silently update the model's node tree. `silent` ensures that
+                    // the change event does not duplicate the move on the frontend
                     this.model.set('nodes', nodes1, {silent: true});
                     this.model.save_changes();
                 } else {

--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -326,28 +326,28 @@ var TreeView = widgets.DOMWidgetView.extend({
             "move_node.jstree", (evt, data) => {
 
                 var nodes1 = [];  // new value for old_parent.children
-                data.instance._model.data[data.old_parent].children.forEach((id) => {
+                data.instance._model.data[data.old_parent].children.slice().forEach((id) => {
                     nodes1.push(nodesRegistry[id]);
                 });
-                
+
                 var nodes2 = [];  // new value for parent.children
-                data.instance._model.data[data.parent].children.forEach((id) => {
+                data.instance._model.data[data.parent].children.slice().forEach((id) => {
                     nodes2.push(nodesRegistry[id]);
                 });
 
                 if (data.old_parent == "#") {
-                    this.model.set('nodes', nodes1);
+                    this.model.set('nodes', nodes1, {silent: true});
                     this.model.save_changes();
                 } else {
-                    nodesRegistry[data.old_parent].set('nodes', nodes1);
+                    nodesRegistry[data.old_parent].set('nodes', nodes1, {silent: true});
                     nodesRegistry[data.old_parent].save_changes();
                 }
-                
+
                 if (data.parent == "#") {
-                    this.model.set('nodes', nodes2);
+                    this.model.set('nodes', nodes2, {silent: true});
                     this.model.save_changes();
                 } else {
-                    nodesRegistry[data.parent].set('nodes', nodes2);
+                    nodesRegistry[data.parent].set('nodes', nodes2, {silent: true});
                     nodesRegistry[data.parent].save_changes();
                 }
             }


### PR DESCRIPTION
I should have some more time to work on this in a couple weeks (after finals). The key findings are the need to add the `dnd` option to the `plugins` list and that move event is called `move_node.jstree`. 

The current logic for updating children nodes and all that (327-353) fails to update other copies of the ipytree widget (due to the silent option) so that needs to be reworked.

Also, there should probably be an option for enabling and disabling `dnd`. I'm not sure how to do that yet.