### PR TITLE
deselect_all only selected_nodes of tree

### DIFF
--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -303,12 +303,11 @@ export class TreeView extends widgets.DOMWidgetView {
             }
         ).bind(
             "deselect_all.jstree", (evt, data) => {
-                for(var id in nodesRegistry) {
-                    if(this.tree.get_node(id)) {
-                        nodesRegistry[id].set('selected', false);
-                        nodesRegistry[id].save_changes();
-                    }
-                }
+                var selected_nodes = this.model.get('selected_nodes');
+                selected_nodes.forEach((model) => {
+                    model.set('selected', false);
+                    model.save_changes();
+                });
             }
         ).bind(
             "after_open.jstree", (evt, data) => {


### PR DESCRIPTION
If we select another node in existing selected node, the tree is happened deselect_all event. Then it iterates all nodesRegistry. It is big overhead. Because it also iterates other tree nodes. So I fixed it. If deselect_all event happend, it only iterates selected nodes.