### PR TITLE
reload icon when node name is changed

### DIFF
--- a/js/lib/tree.js
+++ b/js/lib/tree.js
@@ -183,6 +183,7 @@ export class NodeView extends widgets.WidgetView {
 
     handleNameChange() {
         this.tree.rename_node(this.model.get('_id'), this.model.get('name'));
+        this.setOpenCloseIcon(false);
     }
 
     handleOpenedChange() {


### PR DESCRIPTION
When the name of a node with an open or close icon is changed, this previously set icon disappears.
To prevent this, reload icon after rename_node is called. No need for recursive call because only icon of this particular node was removed.